### PR TITLE
More factory methods in the CompletionStageFactory

### DIFF
--- a/src/main/java/net/javacrumbs/completionstage/CompletionStageFactory.java
+++ b/src/main/java/net/javacrumbs/completionstage/CompletionStageFactory.java
@@ -15,7 +15,10 @@
  */
 package net.javacrumbs.completionstage;
 
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 /**
  * Factory for {@link java.util.concurrent.CompletionStage} implementation.
@@ -38,5 +41,37 @@ public class CompletionStageFactory {
      */
     public <T> CompletableCompletionStage<T> createCompletionStage() {
         return new SimpleCompletionStage<>(defaultAsyncExecutor);
+    }
+    
+    public final <T> CompletionStage<T> completedFuture(T value) {
+        CompletableCompletionStage<T> result = createCompletionStage();
+        result.complete(value);
+        return result;
+    }
+
+    public final <U> CompletionStage<U> supplyAsync(Supplier<U> supplier) {
+        Objects.requireNonNull(supplier, "supplier");
+
+        return completedFuture(null).thenApplyAsync((ignored) -> supplier.get());
+    }
+
+    public final <U> CompletionStage<U> supplyAsync(Supplier<U> supplier, Executor executor) {
+        Objects.requireNonNull(supplier, "supplier");
+        Objects.requireNonNull(executor, "executor");
+
+        return completedFuture(null).thenApplyAsync((ignored) -> supplier.get(), executor);
+    }
+
+    public final CompletionStage<Void> runAsync(Runnable runnable) {
+        Objects.requireNonNull(runnable, "runnable");
+
+        return completedFuture(null).thenRunAsync(runnable);
+    }
+
+    public final CompletionStage<Void> runAsync(Runnable runnable, Executor executor) {
+        Objects.requireNonNull(runnable, "runnable");
+        Objects.requireNonNull(executor, "executor");
+
+        return completedFuture(null).thenRunAsync(runnable, executor);
     }
 }

--- a/src/test/java/net/javacrumbs/completionstage/CompletionStageFactoryTest.java
+++ b/src/test/java/net/javacrumbs/completionstage/CompletionStageFactoryTest.java
@@ -1,0 +1,121 @@
+package net.javacrumbs.completionstage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CompletionStageFactoryTest {
+
+    private CompletionStageFactory factory;
+
+    @Mock
+    private Executor defaultExecutor;
+
+    @Mock
+    private Supplier<String> supplier;
+
+    @Mock
+    private Runnable runnable;
+
+    @Captor
+    private ArgumentCaptor<Runnable> runnableCaptor;
+
+    @Before
+    public void before() {
+        factory = new CompletionStageFactory(defaultExecutor);
+    }
+
+    @Test
+    public void completedFutureTest() throws Exception {
+        CompletionStage<String> stage = factory.completedFuture("test");
+
+        CompletableFuture<String> future = stage.toCompletableFuture();
+        assertTrue(future.isDone());
+        assertEquals("test", future.get());
+    }
+
+    private static void executeCapturedRunnable(ArgumentCaptor<Runnable> runnableCaptor) {
+        runnableCaptor.getValue().run();
+    }
+
+    private void doSupplyAsyncTest(Executor executor, CompletionStage<String> stage, String expectedResult) throws Exception {
+        CompletableFuture<String> future = stage.toCompletableFuture();
+
+        // preconditions:
+        assertFalse(future.isDone());
+        verifyZeroInteractions(supplier);
+
+        verify(executor).execute(runnableCaptor.capture());
+        executeCapturedRunnable(runnableCaptor);
+        verify(supplier).get();
+
+        assertTrue(future.isDone());
+        assertEquals(expectedResult, future.get());
+    }
+
+    @Test
+    public void supplyAsyncTest() throws Exception {
+        when(supplier.get()).thenReturn("test");
+
+        CompletionStage<String> stage = factory.supplyAsync(supplier);
+
+        doSupplyAsyncTest(defaultExecutor, stage, "test");
+    }
+
+    @Test
+    public void supplyAsyncWithExecutorTest() throws Exception {
+        when(supplier.get()).thenReturn("test");
+
+        Executor executor = mock(Executor.class);
+        CompletionStage<String> stage = factory.supplyAsync(supplier, executor);
+        doSupplyAsyncTest(executor, stage, "test");
+    }
+
+    private void doRunAsyncTest(Executor executor, CompletionStage<Void> stage) throws Exception {
+        CompletableFuture<Void> future = stage.toCompletableFuture();
+
+        // preconditions:
+        assertFalse(future.isDone());
+        verifyZeroInteractions(runnable);
+
+        verify(executor).execute(runnableCaptor.capture());
+        executeCapturedRunnable(runnableCaptor);
+        verify(runnable).run();
+
+        assertTrue(future.isDone());
+    }
+
+    @Test
+    public void runAsyncTest() throws Exception {
+        CompletionStage<Void> stage = factory.runAsync(runnable);
+
+        doRunAsyncTest(defaultExecutor, stage);
+    }
+
+    @Test
+    public void runAsyncWithExecutorTest() throws Exception {
+        Executor executor = mock(Executor.class);
+
+        CompletionStage<Void> stage = factory.runAsync(runnable, executor);
+
+        doRunAsyncTest(executor, stage);
+    }
+}


### PR DESCRIPTION
CompletableFuture class has static factory methods like completedFuture, runAsync and supplyAsync which are handy in case you need create a fresh new CompletionStage instance.
Would be nice to have similar method in the CompletionStageFactory class.